### PR TITLE
fix tree view rendering in dark theme

### DIFF
--- a/GitUI/Theming/Renderers/TreeViewRenderer.cs
+++ b/GitUI/Theming/Renderers/TreeViewRenderer.cs
@@ -40,6 +40,11 @@ namespace GitUI.Theming
             {
                 case Parts.TVP_TREEITEM:
                 {
+                    if (poptions.dwFlags.HasFlag(NativeMethods.DTT.TextColor))
+                    {
+                        return Unhandled;
+                    }
+
                     Color foreColor;
                     switch ((State.Item)stateid)
                     {


### PR DESCRIPTION
Ты прав это баг отрисовки дерева в тёмной теме

С этой правкой заработало.

![image](https://user-images.githubusercontent.com/12046452/93023487-fd159a00-f5f7-11ea-9b9a-541b7de6b4ce.png)
